### PR TITLE
[SATPAN-103]: make signalr message processing action as a blocking with conf…

### DIFF
--- a/client.go
+++ b/client.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sync"
+	"time"
 
 	"golang.org/x/sync/errgroup"
 )
@@ -35,7 +36,7 @@ func NewClient(hub string, conn *Conn) *Client {
 		hub:         hub,
 		conn:        conn,
 		invocations: newInvocations(),
-		callbacks:   newCallbacks(conn.config),
+		callbacks:   newCallbacks(conn.config.MaxMessageProcessDuration),
 	}
 }
 
@@ -265,15 +266,15 @@ func (i *invocations) removeAll() {
 }
 
 type callbacks struct {
-	mtx    sync.Mutex
-	config *config
-	data   map[string]*CallbackStream
+	mtx                       sync.Mutex
+	maxMessageProcessDuration time.Duration
+	data                      map[string]*CallbackStream
 }
 
-func newCallbacks(config *config) *callbacks {
+func newCallbacks(maxMessageProcessDuration time.Duration) *callbacks {
 	return &callbacks{
-		data:   make(map[string]*CallbackStream),
-		config: config,
+		data:                      make(map[string]*CallbackStream),
+		maxMessageProcessDuration: maxMessageProcessDuration,
 	}
 }
 
@@ -318,7 +319,7 @@ func (c *callbacks) process(msg *Message) {
 		}
 
 		// if in given time it is not managing to write message we will cancel the context
-		wrCtx, wrCtxCancel := context.WithTimeout(callback.ctx, c.config.MaxMessageProcessDuration)
+		wrCtx, wrCtxCancel := context.WithTimeout(callback.ctx, c.maxMessageProcessDuration)
 
 		select {
 		case <-callback.ctx.Done():
@@ -326,7 +327,6 @@ func (c *callbacks) process(msg *Message) {
 			delete(c.data, method)
 		case callback.ch <- callbackResult{message: clientMsg}:
 		case <-wrCtx.Done():
-			wrCtxCancel()
 			callback.cancel()
 			close(callback.ch)
 			delete(c.data, method)

--- a/config.go
+++ b/config.go
@@ -82,18 +82,26 @@ func MaxReconnectDuration(duration time.Duration) DialOpt {
 	}
 }
 
+// MaxMessageProcessDuration the maximum amount of time to spend on processing message
+func MaxMessageProcessDuration(duration time.Duration) DialOpt {
+	return func(c *config) {
+		c.MaxMessageProcessDuration = duration
+	}
+}
+
 type config struct {
-	Client               *http.Client
-	Dialer               WebsocketDialerFunc
-	Protocol             string
-	Params               url.Values
-	Headers              http.Header
-	MaxNegotiateRetries  int
-	MaxConnectRetries    int
-	MaxReconnectRetries  int
-	MaxReconnectDuration time.Duration
-	MaxStartRetries      int
-	RetryInterval        time.Duration
+	Client                    *http.Client
+	Dialer                    WebsocketDialerFunc
+	Protocol                  string
+	Params                    url.Values
+	Headers                   http.Header
+	MaxNegotiateRetries       int
+	MaxConnectRetries         int
+	MaxReconnectRetries       int
+	MaxReconnectDuration      time.Duration
+	MaxStartRetries           int
+	RetryInterval             time.Duration
+	MaxMessageProcessDuration time.Duration
 }
 
 func (c config) NegotiateBackoff() backoff.BackOff {
@@ -113,17 +121,18 @@ func (c config) StartBackoff() backoff.BackOff {
 }
 
 var defaultConfig = config{
-	Client:               http.DefaultClient,
-	Dialer:               NewDefaultDialer,
-	Protocol:             "1.5",
-	Params:               make(url.Values),
-	Headers:              make(http.Header),
-	MaxNegotiateRetries:  5,
-	MaxConnectRetries:    5,
-	MaxReconnectRetries:  5,
-	MaxReconnectDuration: 5 * time.Minute,
-	MaxStartRetries:      5,
-	RetryInterval:        1 * time.Second,
+	Client:                    http.DefaultClient,
+	Dialer:                    NewDefaultDialer,
+	Protocol:                  "1.5",
+	Params:                    make(url.Values),
+	Headers:                   make(http.Header),
+	MaxNegotiateRetries:       5,
+	MaxConnectRetries:         5,
+	MaxReconnectRetries:       5,
+	MaxReconnectDuration:      5 * time.Minute,
+	MaxStartRetries:           5,
+	RetryInterval:             1 * time.Second,
+	MaxMessageProcessDuration: 10 * time.Second,
 }
 
 func constantBackoff(interval time.Duration, maxRetries int) backoff.BackOff {


### PR DESCRIPTION
## make signalr message processing action as a blocking with configurable timeout

previously we were using non blocking approach in message processing, and in default state we were cancelling the context which was leading us to unexpected problems such as "data channel is closed for unexpected reason" etc.