### PR TITLE
[SRPRO-1673] Headers leak fix & conn close method

### DIFF
--- a/client.go
+++ b/client.go
@@ -40,6 +40,11 @@ func NewClient(hub string, conn *Conn) *Client {
 	}
 }
 
+// Close closes underlying websocket connection
+func (c *Client) Close() error {
+	return c.conn.Close()
+}
+
 func (c *Client) Run(ctx context.Context) error {
 	g, ctx := errgroup.WithContext(ctx)
 

--- a/config.go
+++ b/config.go
@@ -120,19 +120,21 @@ func (c config) StartBackoff() backoff.BackOff {
 	return constantBackoff(c.RetryInterval, c.MaxStartRetries)
 }
 
-var defaultConfig = config{
-	Client:                    http.DefaultClient,
-	Dialer:                    NewDefaultDialer,
-	Protocol:                  "1.5",
-	Params:                    make(url.Values),
-	Headers:                   make(http.Header),
-	MaxNegotiateRetries:       5,
-	MaxConnectRetries:         5,
-	MaxReconnectRetries:       5,
-	MaxReconnectDuration:      5 * time.Minute,
-	MaxStartRetries:           5,
-	RetryInterval:             1 * time.Second,
-	MaxMessageProcessDuration: 10 * time.Second,
+var newDefaultConfig = func() config {
+	return config{
+		Client:                    http.DefaultClient,
+		Dialer:                    NewDefaultDialer,
+		Protocol:                  "1.5",
+		Params:                    make(url.Values),
+		Headers:                   make(http.Header),
+		MaxNegotiateRetries:       5,
+		MaxConnectRetries:         5,
+		MaxReconnectRetries:       5,
+		MaxReconnectDuration:      5 * time.Minute,
+		MaxStartRetries:           5,
+		RetryInterval:             1 * time.Second,
+		MaxMessageProcessDuration: 10 * time.Second,
+	}
 }
 
 func constantBackoff(interval time.Duration, maxRetries int) backoff.BackOff {

--- a/conn.go
+++ b/conn.go
@@ -39,7 +39,7 @@ type State struct {
 
 // Dial connects to Signalr endpoint
 func Dial(ctx context.Context, endpoint, cdata string, opts ...DialOpt) (*Conn, error) {
-	cfg := defaultConfig
+	cfg := newDefaultConfig()
 	for _, opt := range opts {
 		opt(&cfg)
 	}


### PR DESCRIPTION
1. Explicit connection close method added for Client. 
2. Request headers leak fixed. We don't share the same defaultConfig instance anymore but instantiating a new copy instead every time we need default config.

Q: Why we cannot share default config?
A: Because it contains few maps inside and while they are sharing between different client instances they leak inside each other populating/modifying the same request headers, for example.